### PR TITLE
Tf* was renamed to TF* in the custom resource definition for k8s

### DIFF
--- a/0-intro/README.md
+++ b/0-intro/README.md
@@ -5,7 +5,7 @@
 Machine learning model development and operationalization currently has very few industry-wide best practices to help us reduce the time to market and optimize the different steps.
 
 However in traditional application development, DevOps practices are becoming ubiquitous. 
-We can benefit from many of these practices by applying them to model developement and operationalization.
+We can benefit from many of these practices by applying them to model development and operationalization.
 
 Here are a subset of pain points that exists in a typical ML workflow.
 #### A Typical (Simplified) ML Workflow and its Pain Points

--- a/1-docker/README.md
+++ b/1-docker/README.md
@@ -72,7 +72,7 @@ Here a few other docker commands that are important to be aware of for the rest 
 
     The docker `rm` command allows to remove a container.
 
-    From the previous example, we can see that we have a container listed as exited in our environement, or maybe more if we run the same command `docker run -it ubuntu hostname` multiple times. If we want to do some cleaning and remove those executions from our environement we can use the command `docker rm`
+    From the previous example, we can see that we have a container listed as exited in our environment, or maybe more if we run the same command `docker run -it ubuntu hostname` multiple times. If we want to do some cleaning and remove those executions from our environment we can use the command `docker rm`
 
     ```
     $ docker rm gifted_darwin
@@ -84,7 +84,7 @@ Here a few other docker commands that are important to be aware of for the rest 
 
 1. `docker images`
 
-    This command allows us to list all the base images available in the environement.
+    This command allows us to list all the base images available in the environment.
 
     ```
     $ docker images
@@ -238,7 +238,7 @@ So let's push our image to Docker Hub:
 docker push ${DOCKER_USERNAME}/tf-mnist
 ```
 
-If this comand doesn't look familiar to you, make sure you went through part 1 and 2 of Docker's tutorial, and more precisely: [Tutorial - Share your image](https://docs.docker.com/get-started/part2/#share-your-image)
+If this command doesn't look familiar to you, make sure you went through part 1 and 2 of Docker's tutorial, and more precisely: [Tutorial - Share your image](https://docs.docker.com/get-started/part2/#share-your-image)
 
 
 ### Useful Links

--- a/2-kubernetes/README.md
+++ b/2-kubernetes/README.md
@@ -171,7 +171,7 @@ Capacity:
 
 ### Running our Model on Kubernetes
 
-> Note: If you didn't complete the exercise in module 1, you can use `wbuchwalter/tf-mnist` image for this exaercise.
+> Note: If you didn't complete the exercise in module 1, you can use `wbuchwalter/tf-mnist` image for this exercise.
 
 In module 1, we created an image for our MNIST classifier, ran a small training locally and pushed this image to Docker Hub.  
 Since we now have a running Kubernetes cluster, let's run our training on it!

--- a/3-helm/README.md
+++ b/3-helm/README.md
@@ -136,7 +136,7 @@ helm install --name my-wordpress \
 
 ## Create your own Chart
 
-You can also create your own Chart by using the scafolding command `helm create mychart`
+You can also create your own Chart by using the scaffolding command `helm create mychart`
 
 This will create a folder which includes all the files necessary to create your own package :
 

--- a/4-gpus/README.md
+++ b/4-gpus/README.md
@@ -14,25 +14,25 @@ In this module you will learn how to:
 
 ## Important Note
 
-If you created a cluster with CPU VMs only you won't be able to complete the exercises in this module, but it still contains valuable informations that you should read through nonetheless.
+If you created a cluster with CPU VMs only you won't be able to complete the exercises in this module, but it still contains valuable information that you should read through nonetheless.
 
 ## How GPU works with Kubernetes
 
 GPU support in K8s is still in it's early stage, and as such requires a bit of effort on your part to use.
 
-While you don't need to do anything to access a CPU from inside your container (except specifying CPU request and limit optionnaly), getting access to the agent's  GPU is a little bit more tricky:  
+While you don't need to do anything to access a CPU from inside your container (except specifying CPU request and limit optionally), getting access to the agent's  GPU is a little bit more tricky:
 * First, the drivers needs to be installed on the agent, otherwise this agent will not report the presence of GPU, and you won't be able to use it (this is already done for you in ACS/AKS/acs-engine).
-* Then you need to explicitly ask for 1 or mutliple GPU(s) to be mounted into your container, otherwise you will simply not be able to access the GPU, even if is running on a GPU agent.
+* Then you need to explicitly ask for 1 or multiple GPU(s) to be mounted into your container, otherwise you will simply not be able to access the GPU, even if is running on a GPU agent.
 * Finally, and most importantly, you need to mount the drivers from the agent VM into your container.
 
-In Module 5, we will see how this process can be greatly simplified when using TensorFlow with `TfJob`, but for now, let's do it ourselves.
+In Module 5, we will see how this process can be greatly simplified when using TensorFlow with `TFJob`, but for now, let's do it ourselves.
 
 
 ### Creating a container that can benefit from GPU
 
-As a prerequesite for everything else, it is important to make sure that the container we are going to use actually knows what to do with a GPU.
+As a prerequisite for everything else, it is important to make sure that the container we are going to use actually knows what to do with a GPU.
 For example TensorFlow needs to be installed with GPU support. CUDA and cuDNN also needs to be present.  
-Thanksfully, most deep learning framework provide base images that are ready to use with GPU support, so we can use them as base image.
+Thankfully, most deep learning framework provide base images that are ready to use with GPU support, so we can use them as base image.
 
 For example, TensorFlow has a lot of different images ready to use [https://hub.docker.com/r/tensorflow/tensorflow/tags/](https://hub.docker.com/r/tensorflow/tensorflow/tags/) such as:
 * `tensorflow/tensorflow:1.4.0-gpu-py3` for GPU
@@ -42,7 +42,7 @@ CNTK also has pre-built images with or without GPU [https://hub.docker.com/r/mic
 * `microsoft/cntk:2.2-gpu-python3.5-cuda8.0-cudnn6.0` for GPU
 * `microsoft/cntk:2.2-python3.5` for CPU only
 
-Also what's important to note, is that most deep leanring frameworks images are built on top of the official [nvidia/cuda][https://hub.docker.com/r/nvidia/cuda/] image, which already comes with CUDA and cuDNN preinstalled, so you don't need to worry about installing them.
+Also what's important to note, is that most deep learning frameworks images are built on top of the official [nvidia/cuda][https://hub.docker.com/r/nvidia/cuda/] image, which already comes with CUDA and cuDNN preinstalled, so you don't need to worry about installing them.
 
 
 ### Requesting GPU(s)
@@ -53,7 +53,7 @@ By default, if no `limits` is specified for CPU or RAM on a container, K8s will 
 > *To know more on K8s `requests` and `limits`, see [Managing Compute Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/).*
 
 However, things are different for GPUs. If no `limit` is defined for GPU, K8s will run the pod on any node (with or without GPU), and will not expose the GPU even if the node has one. So you need to explicitly set the `limit` to the exact number of GPUs that should be assigned to your container.  
-Also, not that while you can request for a fraction of a CPU, you cannot request a franction of a GPU. One GPU can thus only be assigned to one container at a time.
+Also, not that while you can request for a fraction of a CPU, you cannot request a fraction of a GPU. One GPU can thus only be assigned to one container at a time.
 The name for the GPU resource in K8s is `alpha.kubernetes.io/nvidia-gpu` for versions `1.8` and below and `nvidia.com/gpu` for versions > `1.9`. Note that currently only NVIDIA GPUs are supported.
 
 To set the `limit` for GPU, you should provide a value to `spec.containers[].resources.limits.alpha.kubernetes.io/nvidia-gpu`, in YAML this would looks like:
@@ -83,19 +83,19 @@ For ACS/AKS/acs-engine only Ubuntu nodes are supported so far, so it should be a
 |`/usr/lib/nvidia-384/bin`| NVIDIA binaries |
 |`/usr/lib/x86_64-linux-gnu/libcuda.so.1` | CUDA Driver API library | 
 
-> Note that the NVIDIA driver's version is `384` at the time of this writting, but the driver's location will change as the version change.
+> Note that the NVIDIA driver's version is `384` at the time of this writing, but the driver's location will change as the version change.
 
 For each of the above paths we need to create a corresponding `Volume` and a `VolumeMount` to expose them into our container.  
 
-> To understand how to configure `Volumes` and `VolumeMounts` take a look at [Volumes](https://kubernetes.io/docs/user-guide/walkthrough/#volumes) on the Kubernets documentation.
+> To understand how to configure `Volumes` and `VolumeMounts` take a look at [Volumes](https://kubernetes.io/docs/user-guide/walkthrough/#volumes) on the Kubernetes documentation.
 
-## Excercices
+## Exercises
 
 ### 1. NVIDIA-SMI
 In this first exercise we are simply going to schedule a `Job` that will run `nvidia-smi`, printing details about our GPU from inside the container and exit.
 You don't need to build a custom image, instead, simply use the official `nvidia/cuda` docker image.
 
-Your K8s YAML template should have the following caracteristics:
+Your K8s YAML template should have the following characteristics:
 * It should be a `Job`
 * It should be name `module4-ex1`
 * It should request 1 GPU
@@ -193,7 +193,7 @@ However, this training only used CPU. Let's make things much faster by accelerat
 
 You'll find the code and the `Dockerfile` under [`./src`](./src).
 
-For this excercise, your tasks are to:
+For this exercise, your tasks are to:
 * Modify our `Dockerfile` to use a base image compatible with GPU, such as `tensorflow/tensorflow:1.4.0-gpu`
 * Build and push this new image under a new tag, such as `${DOCKER_USERNAME}/tf-mnist:gpu`
 * Modify the [template we built in module 2](2-kubernetes/training.yaml) to add a GPU `limit` and mount the drivers libraries.
@@ -296,4 +296,4 @@ kubectl create -f <template-path>
 </details>
 
 ## Next Step
-[5 - TfJob](../5-tfjob/README.md)
+[5 - TFJob](../5-tfjob/README.md)

--- a/5-tfjob/README.md
+++ b/5-tfjob/README.md
@@ -1,4 +1,4 @@
-# `tensorflow/k8s` and `TfJob`
+# `tensorflow/k8s` and `TFJob`
 
 ## Prerequisites
 
@@ -53,35 +53,35 @@ We will see in just a moment what each of them do.
 
 ### Kubernetes Custom Resource Definition
 
-Kubernetes has a concept of [Custom Resources](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) (often abreviated CRD) that allows us to create custom object that we will then be able to use.  
-In the case of `tensorflow/k8s`, after installation, a new `TfJob` object will be available in our cluster. This object allows us to describe TensorFlow a training.
+Kubernetes has a concept of [Custom Resources](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) (often abbreviated CRD) that allows us to create custom object that we will then be able to use.
+In the case of `tensorflow/k8s`, after installation, a new `TFJob` object will be available in our cluster. This object allows us to describe TensorFlow a training.
 
-#### `TfJob` Specifications
+#### `TFJob` Specifications
 
-Before going further, let's take a look at what the `TfJob` looks like:
+Before going further, let's take a look at what the `TFJob` looks like:
 
-> Note: Some of the fields are not described here for brievety. 
+> Note: Some of the fields are not described here for brevity.
 
-**`TfJob` Object**
+**`TFJob` Object**
   
 | Field | Type| Description |
 |-------|-----|-------------| 
 | apiVersion | `string` | Versioned schema of this representation of an object. In our case, it's `tensorflow.org/v1alpha1` |
-| kind | `string` |  Value representing the REST resource this object represents. In our case it's `TfJob` |
+| kind | `string` |  Value representing the REST resource this object represents. In our case it's `TFJob` |
 | metadata | [`ObjectMeta`](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata)| Standard object's metadata. |
-| spec | `TfJobSpec` | The actual specification of our TensorFlow job, defined below. |
+| spec | `TFJobSpec` | The actual specification of our TensorFlow job, defined below. |
 
 `spec` is the most important part, so let's look at it too:
 
-**`TfJobSpec` Object**  
+**`TFJobSpec` Object**
 
 | Field | Type| Description |
 |-------|-----|-------------|
-| ReplicaSpecs | `TfReplicaSpec` array | Specification for a set of TensorFlow processes, defined below |
+| ReplicaSpecs | `TFReplicaSpec` array | Specification for a set of TensorFlow processes, defined below |
 
 Let's go deeper: 
 
-**`TfReplicaSpec` Object**  
+**`TFReplicaSpec` Object**
 
 | Field | Type| Description |
 |-------|-----|-------------|
@@ -122,11 +122,11 @@ spec:
         - name: lib
           mountPath: /usr/local/nvidia/lib64
 ```
-Here is what the same thing looks like using the new `TfJob` resource:
+Here is what the same thing looks like using the new `TFJob` resource:
 
 ```yaml
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob
+kind: TFJob
 metadata:
   name: example-tfjob
 spec:
@@ -151,8 +151,8 @@ As we saw earlier, when we installed the Helm chart for `tensorflow/k8s`, 3 reso
 * A `Deployment`
 * And a `Pod` named `tf-job-operator`
 
-The `tf-job-operator` pod (simply called the operator, or `TfJob` operator), is going to monitor your cluster, and everytime you create a new resource of type `TfJob`, the operator will know what to do with it.    
-Specifically, when you create a new `TfJob`, the operator will create a new Kubernetes `Job` for it, and automatically mount the drivers if needed (i.e. when you request a GPU).  
+The `tf-job-operator` pod (simply called the operator, or `TFJob` operator), is going to monitor your cluster, and every time you create a new resource of type `TFJob`, the operator will know what to do with it.
+Specifically, when you create a new `TFJob`, the operator will create a new Kubernetes `Job` for it, and automatically mount the drivers if needed (i.e. when you request a GPU).
 
 You may wonder how the operator knows which directory needs to be mounted in the container for the NVIDIA drivers: that's where the `ConfigMap` comes into play.  
 
@@ -200,20 +200,20 @@ If you want to know more:
 
 ## Exercises 
 
-### Exercise 1: A Simple `TfJob`
+### Exercise 1: A Simple `TFJob`
 
-Let's schedule a very simple TensorFlow job using `TfJob` first.  
+Let's schedule a very simple TensorFlow job using `TFJob` first.
 
-> Note: If you completed the excercise in Module 1 and 2, you can change the image to use the one you pushed instead.
+> Note: If you completed the exercise in Module 1 and 2, you can change the image to use the one you pushed instead.
 
-Depending on wether or not your cluster has GPU, choose the correct template:
+Depending on whether or not your cluster has GPU, choose the correct template:
 
 <details>
 <summary><strong>CPU Only</strong></summary>  
   
 ```yaml
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob
+kind: TFJob
 metadata:
   name: module5-ex1
 spec:
@@ -235,7 +235,7 @@ When using GPU, we need to request for one (or multiple), and the image we are u
 
 ```yaml
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob
+kind: TFJob
 metadata:
   name: module5-ex1-gpu
 spec:
@@ -255,14 +255,14 @@ spec:
   
 
 
-Save the template that applies to you in a file, and create the `TfJob`:
+Save the template that applies to you in a file, and create the `TFJob`:
 ```console
 kubectl create -f <template-path>
 ```
 
 Let's look at what has been created in our cluster.
 
-First a `TfJob` was created:
+First a `TFJob` was created:
 
 ```console
 kubectl get tfjob
@@ -270,7 +270,7 @@ kubectl get tfjob
 Returns:
 ```
 NAME            KIND
-module5-ex1   TfJob.v1alpha1.tensorflow.org
+module5-ex1   TFJob.v1alpha1.tensorflow.org
 ```
 
 As well as a `Job`, which was actually created by the operator:
@@ -328,7 +328,7 @@ kubectl delete tfjob module5-ex1
 
 Well currently we can't. As soon as the training is complete, the container stops and everything inside it, including model and logs are lost.  
 
-Thanksfully, Kubernetes `Volumes` can help us here.  
+Thankfully, Kubernetes `Volumes` can help us here.
 If you remember, we quickly introduced `Volumes` in module [2 - Kubernetes](../2-kubernetes/), and that's what we already used to mount the drivers from the node into the container.  
 But `Volumes` are not just for mounting things from a node, we can also use them to mount a lot of different storage solutions, you can see the full list [here](https://kubernetes.io/docs/concepts/storage/volumes/).  
 
@@ -348,7 +348,7 @@ Once you completed all the steps, run:
 kubectl get secrets
 ```
 
-Which sould return:
+Which should return:
 ```
 NAME                  TYPE                                  DATA      AGE
 azure-secret          Opaque                                2         4m
@@ -387,14 +387,14 @@ This means that when we run a training, all the important data is now stored in 
 
 #### Solution for Exercise 2
 
-*For brievety, the solution show here is for CPU-only training. If you are using GPU, don't forget to update the image tag as well as adding a GPU request.*
+*For brevity, the solution show here is for CPU-only training. If you are using GPU, don't forget to update the image tag as well as adding a GPU request.*
 
 <details>
 <summary><strong>Solution</strong></summary>  
 
 ```yaml
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob
+kind: TFJob
 metadata:
   name: module5-ex2
 spec:
@@ -427,33 +427,33 @@ spec:
 </details>
 
 
-**Don't forget to delete the `TfJob` once it is completed!**
+**Don't forget to delete the `TFJob` once it is completed!**
 
 > Great, but what if I want to check out the training in TensorBoard, do I need to download everything on my machine?
 
-Actually no, you don't. `TfJob` provides a very handy mechanism to monitor your trainings with TensorBaord easily!  
-We will try that in our third excercice.
+Actually no, you don't. `TFJob` provides a very handy mechanism to monitor your trainings with TensorBoard easily!
+We will try that in our third exercise.
 
-### Excercice 3: Adding TensorBoard
+### Exercise 3: Adding TensorBoard
 
 So far, we have a TensorFlow training running, and it's model and summaries are persisted to an Azure File share.  
 But having TensorBoard monitoring the training would be pretty useful as well.
-Turns out `TfJob` can also help us with that.
+Turns out `TFJob` can also help us with that.
 
-When we looked at the `TfJob` specification at the beginning of this module, we omitted some fields in `TfJobSpec` descriptions.
+When we looked at the `TFJob` specification at the beginning of this module, we omitted some fields in `TFJobSpec` descriptions.
 Here is a still incomplete but more accurate representation with one additional field:
 
-**`TfJobSpec` Object**  
+**`TFJobSpec` Object**
 
 | Field | Type| Description |
 |-------|-----|-------------|
-| ReplicaSpecs | `TfReplicaSpec` array | Specification for a set of TensorFlow processes. |
+| ReplicaSpecs | `TFReplicaSpec` array | Specification for a set of TensorFlow processes. |
 | **TensorBoard** | `TensorBoardSpec` | Configuration to start a TensorBoard deployment associated to our training job. Defined below. |
 
-That's right, `TfJobSpec` contains an object of type `TensorBoadSpec` which allows us to describe a TensorBoard instance!  
+That's right, `TFJobSpec` contains an object of type `TensorBoadSpec` which allows us to describe a TensorBoard instance!
 Let's look at it:
 
-**`TensorBoardSpec` Object**  
+**`TensorBoardSpec` Object**
 
 | Field | Type| Description |
 |-------|-----|-------------|
@@ -464,22 +464,22 @@ Let's look at it:
 
 
 Let's add TensorBoard to our job then.
-Here is how this will work: We will keep the same TensorFlow training job as in exercise 2. This `TfJob` will write the model and summaries in the Azure File share.  
+Here is how this will work: We will keep the same TensorFlow training job as in exercise 2. This `TFJob` will write the model and summaries in the Azure File share.
 We will also set up the configuration for TensorBoard so that it reads the summaries from the same Azure File share:
-* `Volumes` and `VolumeMounts` in `TensorBoardSpec` should be updated adequatly.
+* `Volumes` and `VolumeMounts` in `TensorBoardSpec` should be updated adequately.
 * For `ServiceType`, you should use `LoadBalancer`, this will create a public IP so it will be easier to access.
 * `LogDir` will depend on how you configure `VolumeMounts`, but on your file share, the summaries will be under the `training_summaries` sub directory.
 
 #### Solution for Exercise 3
 
-*For brievety, the solution show here is for CPU-only training. If you are using GPU, don't forget to update the image tag as well as adding a GPU request.*
+*For brevity, the solution show here is for CPU-only training. If you are using GPU, don't forget to update the image tag as well as adding a GPU request.*
 
 <details>
 <summary><strong>Solution</strong></summary>  
 
 ```yaml
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob
+kind: TFJob
 metadata:
   name: module5-ex3
 spec:
@@ -518,7 +518,7 @@ spec:
 
 #### Validation
 
-If you updated the `TfJob` template correctly, when doing:
+If you updated the `TFJob` template correctly, when doing:
 ```console
 kubectl get services
 ```

--- a/6-distributed-tensorflow/README.md
+++ b/6-distributed-tensorflow/README.md
@@ -1,16 +1,16 @@
-# Distributed TensorFlow with `TfJob`
+# Distributed TensorFlow with `TFJob`
 
 ## Prerequisites
 
-[5 - TfJob](../5-tfjob/)
+[5 - TFJob](../5-tfjob/)
 
 ## Summary
 
-In this module we will see how `TfJob` can greatly simplify the deployment and monitoring of distributed TensorFlow trainings.
+In this module we will see how `TFJob` can greatly simplify the deployment and monitoring of distributed TensorFlow trainings.
   
 ## "Vanilla" Distributed TensorFlow is Hard
 
-First let's see how we would setup a distributed TensorFlow training without Kubernetes or `TfJob` (fear not, we are not actually going to do that).  
+First let's see how we would setup a distributed TensorFlow training without Kubernetes or `TFJob` (fear not, we are not actually going to do that).
 First, you would have to find or setup a bunch of idle VMs, or physical machines. In most companies, this would already be a feat, and likely require the coordination of multiple department (such as IT) to get the VMs up, running and reserved for your experiment. 
 Then you would likely have to do some back and forth with the IT department to be able to setup your training: the VMs need to be able to talk to each others and have stable endpoints. Work might be needed to access the data, you would need to upload your TF code on every single machine etc.  
 If you add GPU to the mix, it would likely get even harder since GPUs aren't usually just waiting there because of their high cost.  
@@ -63,9 +63,9 @@ If for some reason you want to retrain after a while, you would most likely need
 
 All this hurdles means that in practice very few people actually bother with distributed training as the time gained during training might not be worth the energy and time necessary to set it up correctly.
 
-## Distributed TensorFlow with Kubernetes and `TfJob`
+## Distributed TensorFlow with Kubernetes and `TFJob`
 
-Thanksfully, with Kubernetes and `TfJob` things are much, much simpler, making distributed training something you might actually be able to benefit from.
+Thankfully, with Kubernetes and `TFJob` things are much, much simpler, making distributed training something you might actually be able to benefit from.
 
 
 #### A Small Disclaimer
@@ -76,23 +76,23 @@ The issues we saw in the first part of this module can be categorized in two gro
 The first group of issue is still very dependent on the processes in your company/group. If you need to go through a formal request to get access to extra VMs/GPU, it will still be a hassle and there is nothing Kubernetes can do about that.  
 However, Kubernetes makes this process much easier:
 * On ACS and AKS you can spin up new VMs with a single command: [`az <acs|aks> scale`](https://docs.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az_aks_scale)
-* On acs-engine you can setup autoscaling so that anytime you schedule a training on Kubernetes, the autoscaler will make sure your cluster has all the resources it need to run it, and when your training is completed, it will shut down any idle VMs, making this the best solution in term of cost and effort. While autoscaling is outside the scope of this workshop we will give you pointers in module [8 - Going Furter](../8-going-further).
+* On acs-engine you can setup autoscaling so that anytime you schedule a training on Kubernetes, the autoscaler will make sure your cluster has all the resources it need to run it, and when your training is completed, it will shut down any idle VMs, making this the best solution in term of cost and effort. While autoscaling is outside the scope of this workshop we will give you pointers in module [8 - Going Further](../8-going-further).
 
-Setting up the training, however, is drastically simplified with Kubernetes and `TfJob`.
+Setting up the training, however, is drastically simplified with Kubernetes and `TFJob`.
 
-### Overview of `TfJob` distributed training 
+### Overview of `TFJob` distributed training
 
-So, how does `TfJob` works for distributed training? 
-Let's look again at what the `TfJobSpec`and `TfReplicaSpec` objects looks like:
+So, how does `TFJob` works for distributed training?
+Let's look again at what the `TFJobSpec`and `TFReplicaSpec` objects looks like:
 
-**`TfJobSpec` Object**  
+**`TFJobSpec` Object**
 
 | Field | Type| Description |
 |-------|-----|-------------|
-| ReplicaSpecs | `TfReplicaSpec` array | Specification for a set of TensorFlow processes, defined below |
+| ReplicaSpecs | `TFReplicaSpec` array | Specification for a set of TensorFlow processes, defined below |
 
 
-**`TfReplicaSpec` Object**  
+**`TFReplicaSpec` Object**
 
 Note the last parameter `IsDefaultPS` that we didn't talk about before.
 
@@ -101,17 +101,17 @@ Note the last parameter `IsDefaultPS` that we didn't talk about before.
 | TfReplicaType | `string` | What type of replica are we defining? Can be `MASTER`, `WORKER` or `PS`. When not doing distributed TensorFlow, we just use `MASTER` which happens to be the default value. | 
 | Replicas | `int` | Number of replicas of `TfReplicaType`. Again this is useful only for distributed TensorFLow. Default value is `1`. |
 | Template | [`PodTemplateSpec`](https://kubernetes.io/docs/api-reference/v1.8/#podtemplatespec-v1-core) | Describes the pod that will be created when executing a job. This is the standard Pod description that we have been using everywhere.  |
-| **IsDefaultPS** | `boolean` | Wether the parameter server should be using a default image or a custom one (default to `true`) |
+| **IsDefaultPS** | `boolean` | Whether the parameter server should be using a default image or a custom one (default to `true`) |
 
 In case the distinction between master and workers is not clear, there is a single master per TensorFlow cluster, and it is in fact a worker. The difference is that the master is the worker that is going to handle the creation of the `tf.Session`, write logs and save the model.
 
-As you can see, `TfJobSpec` and `TfReplicaSpec` allow us to easily define the achitecture of the TensorFlow cluster we would like to setup.
+As you can see, `TFJobSpec` and `TFReplicaSpec` allow us to easily define the architecture of the TensorFlow cluster we would like to setup.
 
-Once we have defined this architecure in a `TfJob` template and deployed it with `kubectl create`, the operator will do most of the work for us.  
+Once we have defined this architecture in a `TFJob` template and deployed it with `kubectl create`, the operator will do most of the work for us.
 For each master, worker and parameter server in our TensorFlow cluster, the operator will create a service exposing it so they can communicate.   
 It will then create an internal representation of the cluster with each node and it's associated internal DNS name.  
 
-For example, if you were to create a `TfJob` with 1 `MASTER`, 2 `WORKERS` and 1 `PS`, this representation would look similar to this:
+For example, if you were to create a `TFJob` with 1 `MASTER`, 2 `WORKERS` and 1 `PS`, this representation would look similar to this:
 ```json
 {  
     "master":[  
@@ -153,12 +153,12 @@ For example, here is the value of the `TF_CONFIG` environment variable that woul
 }
 ```
 
-As you can see, this completly takes the responsability of building and maintaining the `ClusterSpec` away from you.  
+As you can see, this completely takes the responsibility of building and maintaining the `ClusterSpec` away from you.
 All you have to do, is modify your code to read the `TF_CONFIG` and act accordingly.
 
-### Modifying your model to use `TfJob`'s `TF_CONFIG`
+### Modifying your model to use `TFJob`'s `TF_CONFIG`
 
-Concretly, let's see how you would modify your code:
+Concretely, let's see how you would modify your code:
 
 ```python
 # Grab the TF_CONFIG environment variable
@@ -187,7 +187,7 @@ server = tf.train.Server(server_def)
 # checking if this process is the chief (also called master). The master has the responsibility of creating the session, saving the summaries etc.
 is_chief = (job_name == 'master')
 
-# Notice that we are not handling the case where job_name == 'ps'. That is because `TfJob` will take care of the parameter servers for us by default.
+# Notice that we are not handling the case where job_name == 'ps'. That is because `TFJob` will take care of the parameter servers for us by default.
 ```
 
 As for any distributed TensorFlow training, you will then also need to modify your model to split the operations and variables among the workers and parameter servers as well as create on session on the master.
@@ -197,13 +197,13 @@ As for any distributed TensorFlow training, you will then also need to modify yo
 ### 1 - Modifying Our MNIST Example to Support Distributed Training
 
 #### 1. a.
-Starting from the MNIST sample we have been working with so far, modify it to work with distributed TensorFlow and `TfJob`.
+Starting from the MNIST sample we have been working with so far, modify it to work with distributed TensorFlow and `TFJob`.
 You will then need to build the image and push it (you should push it under a different name or tag to avoid overwriting what you did before).
 
 #### 1. b.
 
-Modify the yaml template from module [5 - TfJob](../5-tfjob) ecercise 3, to instead deploy 1 master, 2 workers and 1 PS. We also want to monitor the training with TensorBoard.   
-Note that since our model is very simple, TensorFlow will likely use only 1 of the workers, but it will still work fine.  
+Modify the yaml template from module [5 - TFJob](../5-tfjob) exercise 3, to instead deploy 1 master, 2 workers and 1 PS. We also want to monitor the training with TensorBoard.
+Note that since our model is very simple, TensorFlow will likely use only 1 of the workers, but it will still work fine.
 Don't forget to update the image or tag.
 
 #### Validation
@@ -240,7 +240,7 @@ Initialize GrpcChannelCache for job worker -> {0 -> distributed-mnist-worker-5oz
 2017-12-01 20:10:14.395476: I tensorflow/core/distributed_runtime/master_session.cc:1004] Start master session 87c6df6850b8f074 with config:
 ```
 
-This indicates that the `ClusterSpec` was correctly exctracted from the environment variable and given to TensorFlow.
+This indicates that the `ClusterSpec` was correctly extracted from the environment variable and given to TensorFlow.
 
 Once TensorBoard public IP is successfully provisioned (check with `kubectl get svc`), go in TensorBoard's graph section and change the color to Device in the left menu.
 You should see that your model is indeed correctly distributed between workers and PS:  
@@ -254,14 +254,14 @@ After a few minutes, the status of both worker nodes should show as `Completed` 
 #### Solution
 
 
-A working code sample is availbe in [`solution-src/main.py`](./solution-src/main.py).
+A working code sample is available in [`solution-src/main.py`](./solution-src/main.py).
 
 <details>
-<summary><strong>TfJob's Template</strong></summary>  
+<summary><strong>TFJob's Template</strong></summary>
 
 ```yaml
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob
+kind: TFJob
 metadata:
   name: module6-ex1
 spec:
@@ -312,7 +312,7 @@ spec:
 
 There are two things to notice here:
 * Since only the master will be saving the model and the summaries, we only need to mount the Azure File share on the master's `replicaSpec`, not on the `workers` or `ps`.
-* We are not specifying anything for the `PS` `replicaSpec` except the number of replicas. This is because `IsDefaultPS` is set to `true` by default. This means that the parmeter server(s) will be started with a pre-built docker image that is already configured to read the `TF_CONFIG` and act as a TensorFlow server, so we don't need to do anything here.
+* We are not specifying anything for the `PS` `replicaSpec` except the number of replicas. This is because `IsDefaultPS` is set to `true` by default. This means that the parameter server(s) will be started with a pre-built docker image that is already configured to read the `TF_CONFIG` and act as a TensorFlow server, so we don't need to do anything here.
 
 </details>
 

--- a/7-hyperparam-sweep/README.md
+++ b/7-hyperparam-sweep/README.md
@@ -1,9 +1,9 @@
-# Automated Hyperparameters Sweep with `TfJob` and Helm
+# Automated Hyperparameters Sweep with `TFJob` and Helm
 
 ## Prerequisites
 
 * [3 - Helm](../3-helm)
-* [5 - TfJob](../5-tfjob)
+* [5 - TFJob](../5-tfjob)
   
 ### "Vanilla" Hyperparameter Sweep
 
@@ -27,14 +27,14 @@ As we saw in module [3 - Helm](../3-helm), Helm enables us to package an applica
 To do that, Helm allows us to use Golang templating engine in the chart definitions. This means we can use conditions, loops, variables and [much more](https://docs.helm.sh/chart_template_guide).  
 This will allow us to create complex deployment flow.   
 
-In the case of hyperparameters sweeping, we will want a chart able to deploy a number of `TfJobs` each trying different values for some hyperparameters.  
-We will also want to deploy a single TensorBoard instance monitoring all these `TfJobs`, that way we can quickly compare all our hypothesis, and even early-stop jobs that clearly don't perform well if we want to reduce cost as much as possible.
+In the case of hyperparameters sweeping, we will want a chart able to deploy a number of `TFJobs` each trying different values for some hyperparameters.
+We will also want to deploy a single TensorBoard instance monitoring all these `TFJobs`, that way we can quickly compare all our hypothesis, and even early-stop jobs that clearly don't perform well if we want to reduce cost as much as possible.
 For now, this chart will simply do a grid search, and while it is less efficient than random search it will be a good place to start.
 
 ## Exercise
 
 ### Creating and Deploying the Chart
-In this exercise, you will create a new Helm chart that will deploy a number of `TfJobs` as well as a TensorBoard instance.
+In this exercise, you will create a new Helm chart that will deploy a number of `TFJobs` as well as a TensorBoard instance.
 
 Here is what our `values.yaml` file could look like for example (you are free to go a different route):
 
@@ -53,7 +53,7 @@ hyperParamValues:
     - 7
 ```
 
-That way, when installing the chart, 9 `TfJob` will actually get deployed, testing all the combination of learning rate and hidden layers depth that we specified.  
+That way, when installing the chart, 9 `TFJob` will actually get deployed, testing all the combination of learning rate and hidden layers depth that we specified.
 This is a very simple example (our model is also very simple), but hopefully you start to see the possibilities than Helm offers.
 
 In this exercise, we are going to use a new model based on [Andrej Karpathy's Image painting demo](http://cs.stanford.edu/people/karpathy/convnetjs/demo/image_regression.html).  

--- a/7-hyperparam-sweep/solution-chart/templates/deployment.yaml
+++ b/7-hyperparam-sweep/solution-chart/templates/deployment.yaml
@@ -9,11 +9,11 @@
 {{- $chartversion := .Chart.Version -}}
 
 # Then we loop over every value of $lrlist (learning rate) and $nblayerslist (hidden layer depth)
-# This will result in create 1 TfJob for every pair of learning rate and hidden layer depth
+# This will result in create 1 TFJob for every pair of learning rate and hidden layer depth
 {{- range $i, $lr := $lrlist }}
 {{- range $j, $nblayers := $nblayerslist }}
 apiVersion: tensorflow.org/v1alpha1
-kind: TfJob # Each one of our trainings will be a separate TfJob
+kind: TFJob # Each one of our trainings will be a separate TFJob
 metadata:
   name: module7-tf-paint-{{ $i }}-{{ $j }} # We give a unique name to each training
   labels:
@@ -56,7 +56,7 @@ spec:
 ---
 {{- end }}
 {{- end }}
-# We are not using TfJob integrated TensorBoard, because we want to create the Service and Deployment outside of the loop
+# We are not using TFJob integrated TensorBoard, because we want to create the Service and Deployment outside of the loop
 # since we only want one instance running for all our jobs, and not 1 per job.
 apiVersion: v1
 kind: Service

--- a/8-going-further/README.md
+++ b/8-going-further/README.md
@@ -35,7 +35,7 @@ Here are some tools and frameworks that can make it easy to deploy such a distri
 
 ## Autoscaling a Kubernetes Cluster
 
-As we saw in module [6 - Distributed TensorFlow](../6-distributed-tensorflow/) and [7 - Hyperparameters Sweep](../7-hyperparam-sweep), being able to autoscale our Kubernetes cluster can be extremly useful.  
+As we saw in module [6 - Distributed TensorFlow](../6-distributed-tensorflow/) and [7 - Hyperparameters Sweep](../7-hyperparam-sweep), being able to autoscale our Kubernetes cluster can be extremely useful.
 Indeed, automatic scale-out (adding more VMs to the cluster) would allow anyone to run any experiment they want, whenever they want without needing to involve an ops person to setup and prepare virtual machines.  
 And because the cluster can also automatically scale-in by deleting idle VMs once training jobs are completed, we can keep the cost as low as possible by just paying for what we actually use.  
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Clone this repository somewhere so you can easily access the different source fi
 git clone https://github.com/wbuchwalter/tensorflow-k8s-azure
 ```
 
-## Content Sumary
+## Content Summary
 
 | | Module | Description |
 | --- | --- | --- |
@@ -27,8 +27,8 @@ git clone https://github.com/wbuchwalter/tensorflow-k8s-azure
 |2| **[Kubernetes](2-kubernetes)** | Kubernetes important concepts overview.|
 |3| **[Helm](3-helm)** | Introduction to Helm |
 |4| **[GPUs](4-gpus)** | How to use GPUs with Kubernetes.|
-|5| **[TfJob](5-tfjob)** | How to use `tensorflow/k8s` and `TfJob` to deploy a simple TensorFlow training.|
-|6| **[Distributed Tensorflow](6-distributed-tensorflow)** | Going distributed with `TfJob`|
+|5| **[TFJob](5-tfjob)** | How to use `tensorflow/k8s` and `TFJob` to deploy a simple TensorFlow training.|
+|6| **[Distributed Tensorflow](6-distributed-tensorflow)** | Going distributed with `TFJob`|
 |7| **[Hyperparameters Sweep with Helm](7-hyperparam-sweep)** | Using Helm to deploy a large number of training testing different hypothesis, monitoring and comparing them. |
 |8| **[Going Further](8-going-further)** | Links and resources to go further: Autoscaling, Distributed Storage. |
 |9| **[Jupyter Notebooks](9-jupyter)** | Easily deploy a Jupyter Notebook instance on Kubernetes. |


### PR DESCRIPTION
Tf* was renamed to TF* in the custom resource definition for k8s https://github.com/tensorflow/k8s/pull/332

This was causing an error `error: unable to recognize "config.yaml": no matches for tensorflow.org/, Kind=TfJob` where the Kind of job was not identified by following the README. Updated the reference so that people following the guide don't face the same trouble in the future.

Bunch of other spell corrects :)